### PR TITLE
[1.21.1] Fixed framebuffer viewport state

### DIFF
--- a/src/main/java/io/wispforest/affinity/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/io/wispforest/affinity/mixin/client/WorldRendererMixin.java
@@ -13,6 +13,7 @@ import io.wispforest.affinity.object.AffinityItems;
 import io.wispforest.owo.ui.core.Color;
 import io.wispforest.owo.ui.util.Delta;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
@@ -166,7 +167,9 @@ public abstract class WorldRendererMixin {
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;renderSky(Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V", shift = At.Shift.AFTER))
     private void captureSky(RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
-        if (!SkyCaptureBuffer.isIrisWorldRendering() || !Affinity.config().theSkyIrisIntegration()) SkyCaptureBuffer.captureSky(MinecraftClient.getInstance().getFramebuffer().fbo);
+        if (SkyCaptureBuffer.isIrisWorldRendering() && Affinity.config().theSkyIrisIntegration()) return;
+        Framebuffer framebuffer = MinecraftClient.getInstance().getFramebuffer();
+        SkyCaptureBuffer.captureSky(framebuffer.fbo, framebuffer.viewportWidth, framebuffer.viewportHeight);
     }
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/DimensionEffects;isDarkened()Z", shift = At.Shift.AFTER))

--- a/src/main/java/io/wispforest/affinity/mixin/client/iris/HorizonRendererMixin.java
+++ b/src/main/java/io/wispforest/affinity/mixin/client/iris/HorizonRendererMixin.java
@@ -8,11 +8,15 @@ import net.irisshaders.iris.pathways.HorizonRenderer;
 import net.minecraft.client.gl.ShaderProgram;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
+import org.lwjgl.opengl.GL11C;
+import org.lwjgl.system.MemoryStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.nio.IntBuffer;
 
 @Pseudo
 @CompatMixin("iris")
@@ -23,10 +27,15 @@ public class HorizonRendererMixin {
     private void captureShaderSky(Matrix4fc modelView, Matrix4fc projection, ShaderProgram shader, CallbackInfo ci) {
         if (!Affinity.config().theSkyIrisIntegration()) return;
 
-        shader.bind();
-        var fb = GlStateManager.getBoundFramebuffer();
-        shader.unbind();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer viewport = stack.mallocInt(4);
 
-        SkyCaptureBuffer.captureSky(fb);
+            shader.bind();
+            var fb = GlStateManager.getBoundFramebuffer();
+            GL11C.glGetIntegerv(GL11C.GL_VIEWPORT, viewport);
+            shader.unbind();
+
+            SkyCaptureBuffer.captureSky(fb, viewport.get(2), viewport.get(3));
+        }
     }
 }


### PR DESCRIPTION
This PR fixes compatibility with Mirror Mod framebuffers by allowing the framebuffer viewport size to be different from the screen size. The following changes were made:

- `PostEffectBuffer` and `SkyCaptureBuffer` keep track of the viewport state if the bound framebuffer is not the main framebuffer.
- All bind methods pass in `true` to set the viewport to the values specified in `Framebuffer`
- `SkyCaptureBuffer#captureSky` now takes in the viewport size to make sure the state is set/reset correctly
- `GlStateManager#_viewport` is used over `GL11#glViewport` to improve compatibility with other rendering mods like Flywheel (Invalidates caches, etc.)