### PR TITLE
Some issues for the Wispen Testament.

### DIFF
--- a/src/main/resources/assets/affinity/lang/en_us.json
+++ b/src/main/resources/assets/affinity/lang/en_us.json
@@ -887,6 +887,9 @@
       "color": "yellow"
     }
   ],
+  "gui.affinity.item_transfer_node.ignore_damage":"Ignore damage",
+  "gui.affinity.item_transfer_node.ignore_data":"Ignore data",
+  "gui.affinity.item_transfer_node.invert_filter":"Invert filter",
 
   "advancement.affinity.root.title": "Affinity",
   "advancement.affinity.root.description": "Tomfoolery awaits",

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/aethum.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/aethum.md
@@ -40,7 +40,7 @@ functionality...{}
 needs some time to recover{}, to prevent a painful death as outlined previously.
 
 
-All such items (like the numerous [Staffs](^affinity:staffs)), have their usage costs {concept}outlined in their tooltip{}.
+All such items (like the numerous [Staffs](^affinity:staff_prototyping)), have their usage costs {concept}outlined in their tooltip{}.
 
 ---
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/aethum_flux.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/aethum_flux.md
@@ -30,7 +30,7 @@ Of course, further required is a means of...
 
 @next-page
 
-...forming flux (of which there are numerous) - the [Matter Harvesting Hearth](^affinity:matter_harvesting_heart)
+...forming flux (of which there are numerous) - the [Matter Harvesting Hearth](^affinity:matter_harvesting_hearth)
 might present a good starting point.
 
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/crystallized_experience.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/crystallized_experience.md
@@ -30,9 +30,6 @@ leaving behind some sugary {item}Crystallized Experience{}.
 
 @next-page
 
-
-;;;;;
-
 Consuming this clump once more {concept}restores 30 levels worth of experience{} - precisely the amount it took to create
 it in the first place.
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/inquiry.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/inquiry.md
@@ -16,7 +16,7 @@ Being able to obtain detailed information about all sorts of magical contraption
 
 
 The {item}Wand of Inquiry{} (in a certain sense not much more than an educated {item}Eye of Ender{} strapped to an
-[Uncanny Rod](^affinity:uncanny_rod)), thus, is an instrument designed precisely for this purpose.
+[Uncanny Rod](^affinity:wand_of_iridescence)), thus, is an instrument designed precisely for this purpose.
 
 ;;;;;
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/socle_composition.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/socle_composition.md
@@ -18,7 +18,7 @@
 A specialized device is required to assemble the imposing columns of stone, adorned with a special material, that are
 {item}Ritual Socles{}.
 
-<recipe;affinity:assembly/ritual_socle_composer>
+<recipe;affinity:assembly/infused_stone>
 
 ;;;;;
 
@@ -30,14 +30,16 @@ Eerily similar in appearance and function to a {item}Stonecutter{}, the {item}Ri
 
 @next-page
 
+
+<recipe;affinity:assembly/ritual_socle_composer>
+
+
 At this time, the following three materials are known to produce admissible {concept}socle ornaments{}:
+
+;;;;;
 
 <recipe;affinity:ornament_carving/stone_socle_ornament>
 <recipe;affinity:ornament_carving/prismarine_socle_ornament>
 <recipe;affinity:ornament_carving/purpur_socle_ornament>
 
-;;;;;
-
 They provide, in the order listed, an {concept}increasing boost to the stability{} of a ritual's flux-field.
-
-@entry-end

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wand_of_iridescence.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wand_of_iridescence.md
@@ -22,11 +22,18 @@ form networks like those employed to create, transport and process [Aethum Flux]
 
 ;;;;;
 
+<recipe;affinity:assembly/uncanny_rod>
+
+
 <recipe;affinity:assembly/emerald_wand_of_iridescence>
+
+@next-page
 
 To do this, {concept}use the wand on two blocks in succession{} to either create or release the link between them.
 
 
 If you need to join multiple blocks to the same hub, {concept}right-click the wand in your inventory{} to make it
 remember the initial block.
+
+@entry-end
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wisp_forest.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wisp_forest.md
@@ -40,7 +40,7 @@ Hardly any reliable methods to {concept}locate a Wisp Forest{} are known - keepi
 
 The presence of said {concept}Azalea Trees{} in the {concept}Wisp Forests{} is hardly a coincidence - it is due to
 the same [Aethum](^affinity:aethum){concept}-affine properties{} which make their wood the perfect material for
-[Staffs](^affinity:staffs).
+[Staffs](^affinity:staff_prototyping).
 
 @entry-end
 

--- a/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wisps.md
+++ b/src/main/resources/assets/affinity/lavender/entries/wispen_testament/wisps.md
@@ -12,7 +12,7 @@
 }
 ```
 
-Found swarming the vast expanses of the [Wisp Forests](^affinity:wisp_forests) and the former's namesake, the
+Found swarming the vast expanses of the [Wisp Forests](^affinity:wisp_forest) and the former's namesake, the
 {concept}Wisps{} are a curious species. Born of [Aethum](^affinity:aethum), they exhibit only mostly-physical form
 and an innate affinity for all things magical.
 
@@ -37,7 +37,7 @@ discussed on the following pages.
 The {concept}Inert Wisp{} is the most frequent and least distinguished of the bunch.
 
 
-They move in small groups all over the [Wisp Forest](^affinity:wisp_forests), not interested in anything and of no
+They move in small groups all over the [Wisp Forest](^affinity:wisp_forest), not interested in anything and of no
 greater interest to anybody either.
 
 
@@ -58,7 +58,7 @@ qualities of the others.
 <|item-spotlight@lavender:book_components|item=affinity:wise_wisp_matter|>
 
 As implied by their name, the {concept}Wise Wisps{} are the most intelligent inhabitants of the
-[Wisp Forest](^affinity:wisp_forests). They move in groups similar in size to the {concept}Inert Wisps{}, but in lower
+[Wisp Forest](^affinity:wisp_forest). They move in groups similar in size to the {concept}Inert Wisps{}, but in lower
 numbers overall.
 
 
@@ -78,7 +78,7 @@ or the processing of information is required.
 
 <|item-spotlight@lavender:book_components|item=affinity:vicious_wisp_matter|>
 
-Last but not least, the {concept}Vicious Wisps{} are the guards of the [Wisp Forest](^affinity:wisp_forests) and defend
+Last but not least, the {concept}Vicious Wisps{} are the guards of the [Wisp Forest](^affinity:wisp_forest) and defend
 it against any and all intruders.
 
 

--- a/src/main/resources/assets/affinity/owo_ui/item_transfer_node.xml
+++ b/src/main/resources/assets/affinity/owo_ui/item_transfer_node.xml
@@ -45,15 +45,15 @@
                                 <flow-layout direction="vertical">
                                     <children>
                                         <checkbox id="ignore-damage-toggle">
-                                            <text>Ignore damage</text>
+                                            <text translate="true">gui.affinity.item_transfer_node.ignore_damage</text>
                                         </checkbox>
 
                                         <checkbox id="ignore-data-toggle">
-                                            <text>Ignore data</text>
+                                            <text translate="true">gui.affinity.item_transfer_node.ignore_data</text>
                                         </checkbox>
 
                                         <checkbox id="invert-filter-toggle">
-                                            <text>Invert filter</text>
+                                            <text translate="true">gui.affinity.item_transfer_node.invert_filter</text>
                                         </checkbox>
                                     </children>
 


### PR DESCRIPTION
Fixed some invalid internal links (caused by spelling errors or wrong non-existent entries).
﻿
Put the recipe for Uncanny Rod and Infused Stone in the entry of Wispen Testament where they need to be used(So that players can continue the game process through books alone) and re-typeset it.
﻿
Deleted a blank page in the crystallization experience entry.
﻿
Added 3 translatable strings to the gui of the item transfer node in the lang file (I don't know why it didn't use strings before).